### PR TITLE
add symfony/var-dumper required to use the dd function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.2"
+        "php": "^7.2",
+        "symfony/var-dumper": "^4.3"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
`symfony/var-dumper` solves the following error: PHP Fatal error:  Uncaught Error: Call to undefined function dd() in /private/tmp/d/vendor/sixlive/dd-helpers/src/helpers.php:16